### PR TITLE
setting BASE_PATH to prevent storybook from crashing on startup

### DIFF
--- a/recipe/preview.js
+++ b/recipe/preview.js
@@ -6,16 +6,17 @@ import { action } from "@storybook/addon-actions";
 // This global object isn't set in storybook context. We override it to empty functions (no-op),
 // so gatsby link doesn't throw any errors.
 global.___loader = {
-  enqueue: () => {},
-  hovering: () => {},
+    enqueue: () => {},
+    hovering: () => {},
 };
 
 // __PATH_PREFIX__ is used inside gatsby-link an other various places. For storybook not to crash we need to set it as well.
 global.__PATH_PREFIX__ = "";
+global.__BASE_PATH__ = "";
 
 // Navigating through a gatsby app using gatsby-link or any other gatsby component will use the `___navigate` method.
 // In storybook it doesn't make sense to do an actual navigate, instead we want to log an action. Checkout the actions addon docs https://github.com/storybookjs/storybook/tree/master/addons/actions.
 
 window.___navigate = (pathname) => {
-  action("NavigateTo:")(pathname);
+    action("NavigateTo:")(pathname);
 };


### PR DESCRIPTION
Hey Paulie,

Thanks for this recipe, it's super helpful.  Each time I use it, however, Storybook crashes on startup complaining about not having the basepath set.  So I have to go manually add it to the preview file.  Here's a pull request with the fix included.

Best Regards,

Roland